### PR TITLE
extlinux: Add ntfs3 filesystem type support

### DIFF
--- a/extlinux/main.c
+++ b/extlinux/main.c
@@ -1428,7 +1428,8 @@ static int open_device(const char *path, struct stat *st, char **_devname)
     else if (sfs.f_type == MSDOS_SUPER_MAGIC)
 	fs_type = VFAT;
     else if (sfs.f_type == NTFS_SB_MAGIC ||
-                sfs.f_type == FUSE_SUPER_MAGIC /* ntfs-3g */)
+                sfs.f_type == FUSE_SUPER_MAGIC /* ntfs-3g */ ||
+                sfs.f_type == NTFS3_SB_MAGIC)
 	fs_type = NTFS;
     else if (sfs.f_type == XFS_SUPER_MAGIC)
 	fs_type = XFS;

--- a/extlinux/ntfs.h
+++ b/extlinux/ntfs.h
@@ -15,5 +15,6 @@
 
 #define NTFS_SB_MAGIC 0x5346544E
 #define FUSE_SUPER_MAGIC 0x65735546
+#define NTFS3_SB_MAGIC 0x7366746E
 
 #endif /* _NTFS_H_ */


### PR DESCRIPTION
NTFS3 is fully functional NTFS Read-Write driver. The driver works with NTFS versions up to 3.1. Let's add support for it.